### PR TITLE
Element 1.11.45/1.11.46-rc.2 and Synapse 1.94.0rc1

### DIFF
--- a/roles/element/defaults/main.yml
+++ b/roles/element/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 element_version: "{{ element_unstable | ternary(element_unstable_version, element_stable_version) }}"
 element_unstable: false
-element_stable_version: "1.11.42"
-element_unstable_version: "1.11.42"
+element_stable_version: "1.11.45"
+element_unstable_version: "1.11.45"
 element_webapp_dir: /opt/element
 element_config:
   default_server_config:

--- a/roles/element/defaults/main.yml
+++ b/roles/element/defaults/main.yml
@@ -2,7 +2,7 @@
 element_version: "{{ element_unstable | ternary(element_unstable_version, element_stable_version) }}"
 element_unstable: false
 element_stable_version: "1.11.45"
-element_unstable_version: "1.11.45"
+element_unstable_version: "1.11.46-rc.2"
 element_webapp_dir: /opt/element
 element_config:
   default_server_config:

--- a/roles/synapse/defaults/main.yml
+++ b/roles/synapse/defaults/main.yml
@@ -11,7 +11,7 @@ matrix_synapse_signing_key_path: "{{ matrix_synapse_base_path }}/tls/{{ matrix_s
 matrix_synapse_version: "{{ matrix_synapse_unstable | ternary(matrix_synapse_unstable_version, matrix_synapse_stable_version) }}"
 matrix_synapse_unstable: false
 matrix_synapse_stable_version: "1.93.0"
-matrix_synapse_unstable_version: "1.93.0"
+matrix_synapse_unstable_version: "1.94.0rc1"
 matrix_synapse_log_dir: "/var/log/matrix_synapse"
 matrix_synapse_log_days_keep: 14
 matrix_synapse_pid_file: "{{ matrix_synapse_base_path }}/synapse.pid"


### PR DESCRIPTION
- update(synapse): bump unstable version to 1.94.0rc1
- update(element): bump stable version to 1.11.45
- update(element): bump unstable version to 1.11.36-rc.2
