### PR TITLE
Synapse 1.99.0 and Element 1.11.54

### DIFF
--- a/roles/element/defaults/main.yml
+++ b/roles/element/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 element_version: "{{ element_unstable | ternary(element_unstable_version, element_stable_version) }}"
 element_unstable: false
-element_stable_version: "1.11.51"
-element_unstable_version: "1.11.51"
+element_stable_version: "1.11.54"
+element_unstable_version: "1.11.54"
 element_webapp_dir: /opt/element
 element_config:
   default_server_config:

--- a/roles/synapse/README.md
+++ b/roles/synapse/README.md
@@ -1,6 +1,6 @@
 # matrix-synapse
 
-Deploy [synapse](https://github.com/matrix-org/synapse/), a matrix homeserver implementation in python, using ansible.
+Deploy [synapse](https://github.com/element-hq/synapse/), a matrix homeserver implementation in python, using ansible.
 
 The role supports deployment both as systemd-services or as a docker container.
 
@@ -36,11 +36,11 @@ If deploying synapse in a docker container, check that you have `docker` and the
 | :---                                | :---                                                                      | :---                                                                                                                          |
 | `matrix_synapse_base_path`          | "/opt/synapse"                                                            |                                                                                                                               |
 | `matrix_synapse_secrets_path`       | "{{ matrix_synapse_base_path }}/secrets"                                  |                                                                                                                               |
-| `matrix_synapse_extra_config`       | _None_                                                                    | configuration parameters as given in the [synapse configuration file](https://github.com/matrix-org/synapse/tree/master/docs) |
+| `matrix_synapse_extra_config`       | _None_                                                                    | configuration parameters as given in the [synapse configuration file](https://github.com/element-hq/synapse/tree/master/docs) |
 | `matrix_synapse_dh_path`            | "{{ matrix_synapse_base_path }}/tls/{{ matrix_server_name }}.dh"          |                                                                                                                               |
 | `matrix_synapse_public_baseurl`     | "https://{{ matrix_server_name }}"                                        |                                                                                                                               |
 | `matrix_synapse_signing_key_path`   | "{{ matrix_synapse_base_path }}/ssl/{{ matrix_server_name }}.signing.key" |                                                                                                                               |
-| `matrix_synapse_version`            | "v1.98.0"                                                                 |                                                                                                                               |
+| `matrix_synapse_version`            | "v1.99.0"                                                                 |                                                                                                                               |
 | `matrix_synapse_unstable`           | false                                                                     | when true, release candidate versions are deployed too                                                                        |
 | `matrix_synapse_log_days_keep`      | 14                                                                        |                                                                                                                               |
 | `matrix_synapse_deployment_method`  | pip                                                                       | Either pip or docker [¹](#footnote_1)                                                                                         |

--- a/roles/synapse/defaults/main.yml
+++ b/roles/synapse/defaults/main.yml
@@ -10,8 +10,8 @@ matrix_synapse_public_baseurl: "https://{{ matrix_server_name }}"
 matrix_synapse_signing_key_path: "{{ matrix_synapse_base_path }}/tls/{{ matrix_server_name }}.signing.key"
 matrix_synapse_version: "{{ matrix_synapse_unstable | ternary(matrix_synapse_unstable_version, matrix_synapse_stable_version) }}"
 matrix_synapse_unstable: false
-matrix_synapse_stable_version: "1.98.0"
-matrix_synapse_unstable_version: "1.98.0"
+matrix_synapse_stable_version: "1.99.0"
+matrix_synapse_unstable_version: "1.99.0"
 matrix_synapse_log_dir: "/var/log/matrix_synapse"
 matrix_synapse_log_days_keep: 14
 matrix_synapse_pid_file: "{{ matrix_synapse_base_path }}/synapse.pid"


### PR DESCRIPTION
- update(synapse): bump stable version to 1.99.0
- update(element): bump stable version to 1.11.54
