### PR TITLE
fix(synapse): don't install signedjson with pip

### DIFF
--- a/roles/synapse/tasks/crypto.yml
+++ b/roles/synapse/tasks/crypto.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install signedjson
-  pip:
-    name: signedjson
+  ansible.builtin.apt:
+    name: python3-signedjson
   tags: ['prepare', 'prepare-synapse']
 
 - name: Create signing key


### PR DESCRIPTION
Debian 12 brings with it Python 3.12, which in turn forces the use of the system package manager for modifying the global env. This is good. While it is good, it also breaks a bunch of our stuff, for example this bit of the Synapse role.
