### PR TITLE
fix(synapse): use appservice group IDs instead of group names

### DIFF
--- a/roles/synapse/tasks/deploy_workers.yml
+++ b/roles/synapse/tasks/deploy_workers.yml
@@ -44,7 +44,8 @@
         entrypoint: "python"
         command: "{{ item.container_command }}"
         env: "{{ matrix_synapse_docker_env }}"
-        user: "{{ synapse_user.uid }}:{{ appservice_group.gid }}"
+        user: "{{ synapse_user.uid }}:{{ synapse_user.group }}"
+        groups: "{{ appservice_group.results | map(attribute='gid') }}"
         volumes: "{{ matrix_synapse_docker_volumes + item.extra_volumes }}"
         ports: "{{ item.ports | default(omit) }}"
         healthcheck:

--- a/roles/synapse/tasks/deployment.yml
+++ b/roles/synapse/tasks/deployment.yml
@@ -79,7 +79,7 @@
     entrypoint: "{{ matrix_synapse_docker_entrypoint }}"
     command: "{{ matrix_synapse_docker_command }}"
     user: "{{ synapse_user.uid }}:{{ synapse_user.group }}"
-    groups: "{{ matrix_synapse_appservice_groups }}"
+    groups: "{{ appservice_group.results | map(attribute='gid') }}"
     volumes: "{{ matrix_synapse_docker_volumes }}"
     restart_policy: unless-stopped
     state: started


### PR DESCRIPTION
This fixes that the groups aren't available by name in the container
image, so we're using the IDs instead.
