### PR TITLE
update(synapse): bump stable version to 1.117.0

### DIFF
--- a/roles/synapse/defaults/main.yml
+++ b/roles/synapse/defaults/main.yml
@@ -10,8 +10,8 @@ matrix_synapse_public_baseurl: "https://{{ matrix_server_name }}"
 matrix_synapse_signing_key_path: "{{ matrix_synapse_base_path }}/tls/{{ matrix_server_name }}.signing.key"
 matrix_synapse_version: "{{ matrix_synapse_unstable | ternary(matrix_synapse_unstable_version, matrix_synapse_stable_version) }}"
 matrix_synapse_unstable: false
-matrix_synapse_stable_version: "1.114.0"
-matrix_synapse_unstable_version: "1.115.0rc2"
+matrix_synapse_stable_version: "1.117.0"
+matrix_synapse_unstable_version: "1.117.0"
 matrix_synapse_log_dir: "/var/log/matrix_synapse"
 matrix_synapse_log_days_keep: 14
 matrix_synapse_pid_file: "{{ matrix_synapse_base_path }}/synapse.pid"


### PR DESCRIPTION
This is needed, so ldap3 is included. There do not seem to be relevant changes in the synapse changelog.