### PR TITLE
update(synapse): bump version to 1.127.1

### DIFF
--- a/roles/synapse/defaults/main.yml
+++ b/roles/synapse/defaults/main.yml
@@ -10,8 +10,8 @@ matrix_synapse_public_baseurl: "https://{{ matrix_server_name }}"
 matrix_synapse_signing_key_path: "{{ matrix_synapse_base_path }}/tls/{{ matrix_server_name }}.signing.key"
 matrix_synapse_version: "{{ matrix_synapse_unstable | ternary(matrix_synapse_unstable_version, matrix_synapse_stable_version) }}"
 matrix_synapse_unstable: false
-matrix_synapse_stable_version: "1.125.0"
-matrix_synapse_unstable_version: "1.125.0"
+matrix_synapse_stable_version: "1.127.1"
+matrix_synapse_unstable_version: "1.127.1"
 matrix_synapse_log_dir: "/var/log/matrix_synapse"
 matrix_synapse_log_days_keep: 14
 matrix_synapse_pid_file: "{{ matrix_synapse_base_path }}/synapse.pid"


### PR DESCRIPTION
contains a fix for https://github.com/element-hq/synapse/security/advisories/GHSA-v56r-hwv5-mxg6