### PR TITLE
Hedwig: Fix broken registry

### DIFF
--- a/roles/hedwig/defaults/main.yml
+++ b/roles/hedwig/defaults/main.yml
@@ -24,7 +24,7 @@ hedwig_container_image_repository: >-
     + hedwig_container_image_namespace | default('')
     + hedwig_container_image_name
   }}
-hedwig_container_image_registry: "registry.famedly.net/docker"
+hedwig_container_image_registry: "docker.nexus.famedly.de"
 hedwig_container_image_namespace: ""
 hedwig_container_image_name: "hedwig"
 


### PR DESCRIPTION
Reverts https://github.com/famedly/ansible-collection-matrix/commit/5be185fc9d7119284e413b467ae964e26f139e2a and https://github.com/famedly/ansible-collection-matrix/commit/30562f0be6c50adb47010479342b9b0a6aa73b6e as with those commits changing the registry to another one, all pulls fail:

```
[transcaffeine@iodine ~]$ sudo docker image pull registry.famedly.net/docker-releases/hedwig:v2.0.0
Error response from daemon: unauthorized: unauthorized to access repository: docker-releases/hedwig, action: pull: unauthorized to access repository: docker-releases/hedwig, action: pull
```
Without those commits, pulls work again.

Also FYI:
<img width="1920" height="219" alt="image" src="https://github.com/user-attachments/assets/cca5086a-b05f-449d-9a4b-12591bd8437d" />
 (cc: @nikzen)