### PR TITLE
INFRA-108 fix(synapse-container): order of the restart main b4 workers

### DIFF
--- a/roles/synapse/tasks/deploy_workers.yml
+++ b/roles/synapse/tasks/deploy_workers.yml
@@ -41,6 +41,7 @@
         restart_policy: unless-stopped
         state: started
         pull: false
+        recreate: "{{ matrix_synapse_container_started.changed | default(false) }}"
         entrypoint: "python"
         command: "{{ item.container_command }}"
         env: "{{ matrix_synapse_docker_env }}"

--- a/roles/synapse/tasks/main.yml
+++ b/roles/synapse/tasks/main.yml
@@ -26,14 +26,14 @@
   include_tasks: configure.yml
   tags: ['always']
 
+- name: Deploy synapse
+  include_tasks: deployment.yml
+  tags: ['always']
+
 - name: Deploy workers
   import_tasks: deploy_workers.yml
   tags: ['deploy', 'deploy-synapse']
   when: matrix_synapse_workers_enabled
-
-- name: Deploy synapse
-  include_tasks: deployment.yml
-  tags: ['always']
 
 - name: Configure service
   import_tasks: systemd.yml

--- a/roles/synapse/tasks/main.yml
+++ b/roles/synapse/tasks/main.yml
@@ -17,14 +17,14 @@
   tags: ['prepare', 'prepare-synapse',
          'deploy', 'deploy-synapse']
 
+- name: Configure synapse
+  include_tasks: configure.yml
+  tags: ['always']
+
 - name: Configure workers
   import_tasks: configure_workers.yml
   tags: ['deploy', 'deploy-synapse']
   when: matrix_synapse_workers_enabled
-
-- name: Configure synapse
-  include_tasks: configure.yml
-  tags: ['always']
 
 - name: Deploy synapse
   include_tasks: deployment.yml


### PR DESCRIPTION
Ref [INFRA-108](https://famedly.atlassian.net/browse/INFRA-108). Resolves famedly/product-management#3844 (presence broken on `famedly.de`).

### Why

Workers must start *after* main for presence / replication to work. Two bugs violate that:

1. `roles/synapse/tasks/main.yml` runs `deploy_workers.yml` before `deployment.yml` — workers come up before main on every run that (re)creates containers.
2. `deployment.yml` recreates main on image-digest / spec changes, but `deploy_workers.yml` passes `pull: false` and has no `recreate` toggle — workers stay on the old process. This is the exact `famedly.de` state in product-management#3844: main newer than workers, presence 404s.

### What

- `roles/synapse/tasks/main.yml`: swap `Deploy synapse` and `Deploy workers` so main runs first. Matches the existing `restart-matrix-synapse` handler, which already iterates `[main] + workers`.
- `roles/synapse/tasks/deploy_workers.yml`: add `recreate: "{{ matrix_synapse_container_started.changed | default(false) }}"` to the worker `docker_container` task. When main recreated in the same run, workers recreate right after; otherwise unchanged.

Handler and `deployment.yml` untouched.

### Risk check

`rg matrix_synapse_docker_recreate inventory/ ansible_collections/` — only the default in `roles/synapse/defaults/main.yml` (`false`), no overrides. Propagation only fires on genuine main recreations, not every run.

[INFRA-108]: https://famedly.atlassian.net/browse/INFRA-108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ