### PR TITLE
fix(synapse): wait on container health status instead of host port [INFRA-246]

### DIFF
--- a/roles/synapse/defaults/main.yml
+++ b/roles/synapse/defaults/main.yml
@@ -31,7 +31,6 @@ matrix_synapse_docker_command:
   - "{{ matrix_synapse_base_path }}/homeserver.yaml"
 matrix_synapse_container_name: "synapse"
 # Used so workers only start after main is up (INFRA-108 / FP-247)
-matrix_synapse_healthcheck_url: "http://127.0.0.1:8008/health"
 matrix_synapse_healthcheck_retries: 30
 matrix_synapse_healthcheck_delay: 2
 matrix_synapse_appservice_groups: []

--- a/roles/synapse/handlers/main.yml
+++ b/roles/synapse/handlers/main.yml
@@ -21,11 +21,10 @@
   listen: restart-matrix-synapse
 
 - name: Wait for synapse main to become healthy (Docker)
-  ansible.builtin.uri:
-    url: "{{ matrix_synapse_healthcheck_url }}"
-    status_code: 200
+  community.docker.docker_container_info:
+    name: "{{ matrix_synapse_container_name }}"
   register: matrix_synapse_healthcheck
-  until: matrix_synapse_healthcheck is successful
+  until: matrix_synapse_healthcheck.container.State.Health.Status | default('') == 'healthy'
   retries: "{{ matrix_synapse_healthcheck_retries }}"
   delay: "{{ matrix_synapse_healthcheck_delay }}"
   when:

--- a/roles/synapse/tasks/deploy_workers.yml
+++ b/roles/synapse/tasks/deploy_workers.yml
@@ -26,14 +26,13 @@
       loop: "{{ matrix_synapse_running_workers | difference(matrix_synapse_workers | map(attribute='container_name')) }}"
 
     - name: Wait for synapse main to become healthy (Docker)
-      ansible.builtin.uri:
-        url: "{{ matrix_synapse_healthcheck_url }}"
-        status_code: 200
+      community.docker.docker_container_info:
+        name: "{{ matrix_synapse_container_name }}"
       register: matrix_synapse_healthcheck
-      until: matrix_synapse_healthcheck is successful
+      until: matrix_synapse_healthcheck.container.State.Health.Status | default('') == 'healthy'
       retries: "{{ matrix_synapse_healthcheck_retries }}"
       delay: "{{ matrix_synapse_healthcheck_delay }}"
-      
+
     - name: Deploy workers (docker)
       community.docker.docker_container:
         name: "{{ item.container_name }}"


### PR DESCRIPTION
## Summary

INFRA-246 added a "Wait for synapse main to become healthy (Docker)" task (`8102f53`) that polls `http://127.0.0.1:8008/health` on the target host via the `uri` module. This can never succeed on the Famedly fleet: `ansible-environment` overrides `matrix_synapse_docker_ports` to publish only the worker replication port (traefik reaches synapse over the Docker network), so nothing listens on host `127.0.0.1:8008` and every attempt fails with `Connection refused`. First observed on `sum.dev.famedly.de`, but it affects every workers-enabled host on any restart-triggering deploy.

This PR replaces the host-port poll with a poll of the container's own Docker health status via `community.docker.docker_container_info`, retrying until `State.Health.Status == "healthy"`. The synapse image ships its own healthcheck (`curl -fSs http://localhost:8008/health`, 15s interval), which runs inside the container and is independent of host port publishing. The now-unused `matrix_synapse_healthcheck_url` default is removed; `matrix_synapse_healthcheck_retries`/`_delay` are kept and still control the polling window (~60s). The `| default('')` guard keeps the `until` expression retrying (instead of erroring) if the container doesn't exist yet.

## Test plan

- Verified on `sum.dev.famedly.de`: the synapse container reports `healthy` via `docker inspect --format '{{.State.Health.Status}}'` while host port 8008 is unpublished, i.e. the old check fails and the new condition passes.
- `ansible-lint` (production profile) and `yamllint` pass on the three changed files.
- Deploy to a workers-enabled test host (e.g. `--limit sum.dev.famedly.de`) and confirm the "Wait for synapse main to become healthy (Docker)" task now succeeds during worker deploy/restart.